### PR TITLE
Add babel-core to dev dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
     "wait-until": "^0.0.2"
   },
   "devDependencies": {
-    "webpack": "^3.3.0",
+    "babel-core": "^6.25.0",
     "babel-loader": "^7.1.1",
     "babel-preset-es2015": "^6.24.1",
-    "babel-preset-react": "^6.24.1"
+    "babel-preset-react": "^6.24.1",
+    "webpack": "^3.3.0"
   }
 }


### PR DESCRIPTION
This was required for me to be able to run the webpack config locally.